### PR TITLE
Unify adoption tracking to labels and harden PVC resolution

### DIFF
--- a/api/v1beta1/ogxserver_types.go
+++ b/api/v1beta1/ogxserver_types.go
@@ -50,11 +50,8 @@ const (
 	AdoptStorageAnnotation = "ogx.io/adopt-storage"
 	// AdoptNetworkingAnnotation triggers Service/Ingress adoption from a legacy LlamaStackDistribution.
 	AdoptNetworkingAnnotation = "ogx.io/adopt-networking"
-	// AdoptedFromLabel is set on adopted PVCs to record the legacy source.
-	// A label (not annotation) enables server-side filtering via MatchingLabels.
+	// AdoptedFromLabel is set on adopted resources to record the legacy source.
 	AdoptedFromLabel = "ogx.io/adopted-from"
-	// AdoptedFromAnnotation is set on adopted networking resources to record the legacy source.
-	AdoptedFromAnnotation = "ogx.io/adopted-from"
 	// AdoptedAtAnnotation is set on adopted child resources with an RFC 3339 timestamp.
 	AdoptedAtAnnotation = "ogx.io/adopted-at"
 )

--- a/api/v1beta1/provider_types_inference.go
+++ b/api/v1beta1/provider_types_inference.go
@@ -173,11 +173,12 @@ func (p AzureProvider) DeriveID() string { return p.deriveOrDefault("remote-azur
 
 // BedrockProvider configures a remote::bedrock inference provider instance.
 // +kubebuilder:validation:XValidation:rule="!has(self.awsRoleArn) || self.awsRoleArn.size() > 0",message="awsRoleArn must not be empty if specified"
-//nolint:lll // kubebuilder marker cannot be split across lines.
 // +kubebuilder:validation:XValidation:rule="!has(self.awsWebIdentityTokenFile) || self.awsWebIdentityTokenFile.size() > 0",message="awsWebIdentityTokenFile must not be empty if specified"
 // +kubebuilder:validation:XValidation:rule="!has(self.awsRoleSessionName) || self.awsRoleSessionName.size() > 0",message="awsRoleSessionName must not be empty if specified"
 // +kubebuilder:validation:XValidation:rule="!has(self.profileName) || self.profileName.size() > 0",message="profileName must not be empty if specified"
 // +kubebuilder:validation:XValidation:rule="!has(self.retryMode) || self.retryMode.size() > 0",message="retryMode must not be empty if specified"
+//
+//nolint:lll // kubebuilder marker cannot be split across lines.
 type BedrockProvider struct {
 	RoutedProviderBase          `json:",inline"`
 	RemoteInferenceCommonConfig `json:",inline"`

--- a/config/certmanager/kustomization.yaml
+++ b/config/certmanager/kustomization.yaml
@@ -1,6 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+namespace: ogx-k8s-operator-system
+namePrefix: ogx-k8s-operator-
+
 resources:
 - certificate.yaml
 

--- a/controllers/legacy_adoption.go
+++ b/controllers/legacy_adoption.go
@@ -288,12 +288,11 @@ func (r *OGXServerReconciler) adoptLegacyService(ctx context.Context, instance *
 		return true, nil
 	}
 
-	// Update selectors to route traffic to new pods.
-	if svc.Spec.Selector == nil {
-		svc.Spec.Selector = make(map[string]string)
+	// Replace selectors to route traffic to new pods.
+	svc.Spec.Selector = map[string]string{
+		ogxiov1beta1.DefaultLabelKey: ogxiov1beta1.DefaultLabelValue,
+		instanceLabelKey:             instance.Name,
 	}
-	svc.Spec.Selector[ogxiov1beta1.DefaultLabelKey] = ogxiov1beta1.DefaultLabelValue
-	svc.Spec.Selector[instanceLabelKey] = instance.Name
 
 	if err := r.transferOwnership(ctx, instance, svc, legacyName); err != nil {
 		return false, err
@@ -403,12 +402,18 @@ func (r *OGXServerReconciler) transferOwnership(ctx context.Context, instance *o
 	}
 	obj.SetOwnerReferences(filtered)
 
-	// Set adoption audit annotations.
+	// Set adoption audit label and timestamp annotation.
+	labels := obj.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	labels[ogxiov1beta1.AdoptedFromLabel] = legacySource
+	obj.SetLabels(labels)
+
 	annotations := obj.GetAnnotations()
 	if annotations == nil {
 		annotations = make(map[string]string)
 	}
-	annotations[ogxiov1beta1.AdoptedFromAnnotation] = legacySource
 	annotations[ogxiov1beta1.AdoptedAtAnnotation] = metav1.Now().UTC().Format(time.RFC3339)
 	obj.SetAnnotations(annotations)
 
@@ -458,13 +463,13 @@ func (r *OGXServerReconciler) cleanupAdoptedNetworking(ctx context.Context, inst
 func (r *OGXServerReconciler) cleanupAdoptedServices(ctx context.Context, instance *ogxiov1beta1.OGXServer) error {
 	logger := log.FromContext(ctx)
 	ownedServices := &corev1.ServiceList{}
-	if err := r.List(ctx, ownedServices, client.InNamespace(instance.Namespace)); err != nil {
+	if err := r.List(ctx, ownedServices, client.InNamespace(instance.Namespace), client.HasLabels{ogxiov1beta1.AdoptedFromLabel}); err != nil {
 		return fmt.Errorf("failed to list services for adoption cleanup: %w", err)
 	}
 
 	for i := range ownedServices.Items {
 		svc := &ownedServices.Items[i]
-		if !shouldDeleteAdoptedResource(instance, svc.GetAnnotations(), svc) {
+		if !shouldDeleteAdoptedResource(instance, svc) {
 			continue
 		}
 		logger.Info("Deleting adopted legacy Service after annotation removal", "service", svc.Name)
@@ -479,13 +484,13 @@ func (r *OGXServerReconciler) cleanupAdoptedServices(ctx context.Context, instan
 func (r *OGXServerReconciler) cleanupAdoptedIngresses(ctx context.Context, instance *ogxiov1beta1.OGXServer) error {
 	logger := log.FromContext(ctx)
 	ownedIngresses := &networkingv1.IngressList{}
-	if err := r.List(ctx, ownedIngresses, client.InNamespace(instance.Namespace)); err != nil {
+	if err := r.List(ctx, ownedIngresses, client.InNamespace(instance.Namespace), client.HasLabels{ogxiov1beta1.AdoptedFromLabel}); err != nil {
 		return fmt.Errorf("failed to list ingresses for adoption cleanup: %w", err)
 	}
 
 	for i := range ownedIngresses.Items {
 		ing := &ownedIngresses.Items[i]
-		if !shouldDeleteAdoptedResource(instance, ing.GetAnnotations(), ing) {
+		if !shouldDeleteAdoptedResource(instance, ing) {
 			continue
 		}
 		logger.Info("Deleting adopted legacy Ingress after annotation removal", "ingress", ing.Name)
@@ -499,13 +504,12 @@ func (r *OGXServerReconciler) cleanupAdoptedIngresses(ctx context.Context, insta
 
 func shouldDeleteAdoptedResource(
 	instance *ogxiov1beta1.OGXServer,
-	annotations map[string]string,
 	obj metav1.Object,
 ) bool {
 	if !metav1.IsControlledBy(obj, instance) {
 		return false
 	}
-	_, hasAdopted := annotations[ogxiov1beta1.AdoptedFromAnnotation]
+	_, hasAdopted := obj.GetLabels()[ogxiov1beta1.AdoptedFromLabel]
 	return hasAdopted
 }
 
@@ -586,7 +590,20 @@ func (r *OGXServerReconciler) resolveEffectivePVCName(ctx context.Context, insta
 		return "", fmt.Errorf("failed to list adopted PVCs: %w", err)
 	}
 
-	if len(pvcList.Items) > 0 {
+	if len(pvcList.Items) > 1 {
+		names := make([]string, len(pvcList.Items))
+		for i := range pvcList.Items {
+			names[i] = pvcList.Items[i].Name
+		}
+		msg := fmt.Sprintf("multiple adopted PVCs found for instance %q: %v; remove the %s label from all but one",
+			instance.Name, names, ogxiov1beta1.AdoptedFromLabel)
+		logger := log.FromContext(ctx)
+		logger.Error(nil, msg)
+		SetAdoptionConfigInvalidCondition(&instance.Status, msg)
+		return "", &terminalError{message: msg}
+	}
+
+	if len(pvcList.Items) == 1 {
 		return pvcList.Items[0].Name, nil
 	}
 

--- a/controllers/legacy_adoption_test.go
+++ b/controllers/legacy_adoption_test.go
@@ -228,7 +228,7 @@ func TestAdoptNetworking(t *testing.T) {
 				require.Equal(t, instance.Name, svc.Spec.Selector["app.kubernetes.io/instance"],
 					"Service selector should target the new instance")
 
-				require.Equal(t, "old-llsd", svc.Annotations[ogxiov1beta1.AdoptedFromAnnotation])
+				require.Equal(t, "old-llsd", svc.Labels[ogxiov1beta1.AdoptedFromLabel])
 				require.NotEmpty(t, svc.Annotations[ogxiov1beta1.AdoptedAtAnnotation])
 
 				assertConditionTrue(t, instance, "NetworkingAdopted")
@@ -256,7 +256,7 @@ func TestAdoptNetworking(t *testing.T) {
 						metav1.IsControlledBy(ingress, instance)
 				}, testTimeout, testInterval, "Ingress should be owned by new instance")
 
-				require.Equal(t, "old-llsd", ingress.Annotations[ogxiov1beta1.AdoptedFromAnnotation])
+				require.Equal(t, "old-llsd", ingress.Labels[ogxiov1beta1.AdoptedFromLabel])
 				require.NotEmpty(t, ingress.Annotations[ogxiov1beta1.AdoptedAtAnnotation])
 			},
 		},
@@ -583,10 +583,15 @@ func TestSelfAdoptionRejectedByController(t *testing.T) {
 	assertConditionTrue(t, instance, "AdoptionConfigInvalid")
 }
 
-func TestAdoptedPVCDiscoveredByLabelAfterAnnotationRemoval(t *testing.T) {
+func TestAdoptedPVCLifecycle(t *testing.T) {
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
-	namespace := createTestNamespace(t, "adopt-pvc-label-disc")
+	namespace := createTestNamespace(t, "adopt-pvc-lifecycle")
 	createLegacyPVC(t, namespace.Name, "disc-legacy")
+
+	// --- arrange ---
+	pvcKey := types.NamespacedName{Name: "disc-legacy-pvc", Namespace: namespace.Name}
+	defaultKey := types.NamespacedName{Name: "disc-server-pvc", Namespace: namespace.Name}
+	deployKey := types.NamespacedName{Name: "disc-server", Namespace: namespace.Name}
 
 	instance := NewOGXServerBuilder().
 		WithName("disc-server").
@@ -596,22 +601,19 @@ func TestAdoptedPVCDiscoveredByLabelAfterAnnotationRemoval(t *testing.T) {
 		Build()
 
 	require.NoError(t, k8sClient.Create(t.Context(), instance))
-	t.Cleanup(func() {
-		if err := k8sClient.Delete(t.Context(), instance); err != nil && !apierrors.IsNotFound(err) {
-			t.Logf("Cleanup: %v", err)
-		}
-	})
 
-	// First reconcile adopts the PVC (sets label, strips old ownerRef).
+	// --- act: adopt PVC, then remove annotation ---
 	ReconcileOGXServer(t, instance)
+
 	pvc := &corev1.PersistentVolumeClaim{}
-	pvcKey := types.NamespacedName{Name: "disc-legacy-pvc", Namespace: namespace.Name}
 	require.Eventually(t, func() bool {
 		return k8sClient.Get(t.Context(), pvcKey, pvc) == nil &&
 			pvc.Labels[ogxiov1beta1.AdoptedFromLabel] == "disc-legacy"
 	}, testTimeout, testInterval, "PVC should be adopted with label")
 
-	// Remove the annotation and reconcile again.
+	deployment := &appsv1.Deployment{}
+	waitForResource(t, k8sClient, namespace.Name, "disc-server", deployment)
+
 	require.NoError(t, k8sClient.Get(t.Context(), types.NamespacedName{
 		Name: instance.Name, Namespace: instance.Namespace,
 	}, instance))
@@ -620,16 +622,55 @@ func TestAdoptedPVCDiscoveredByLabelAfterAnnotationRemoval(t *testing.T) {
 
 	ReconcileOGXServer(t, instance)
 
-	// The adopted PVC should still exist (not garbage collected).
+	// --- assert: adopted PVC discovered by label, Deployment uses it ---
 	require.NoError(t, k8sClient.Get(t.Context(), pvcKey, pvc),
 		"Adopted PVC must survive annotation removal")
-
-	// No new default PVC should be created — the controller should discover
-	// the adopted PVC by label and keep using it.
-	defaultPVC := &corev1.PersistentVolumeClaim{}
-	defaultKey := types.NamespacedName{Name: "disc-server-pvc", Namespace: namespace.Name}
-	require.True(t, apierrors.IsNotFound(k8sClient.Get(t.Context(), defaultKey, defaultPVC)),
+	require.True(t, apierrors.IsNotFound(k8sClient.Get(t.Context(), defaultKey, &corev1.PersistentVolumeClaim{})),
 		"Default PVC should NOT be created when adopted PVC is discovered by label")
+
+	require.NoError(t, k8sClient.Get(t.Context(), deployKey, deployment))
+	AssertDeploymentUsesPVCStorage(t, deployment, "disc-legacy-pvc")
+
+	// --- act: delete OGXServer ---
+	require.NoError(t, k8sClient.Delete(t.Context(), instance))
+	require.Eventually(t, func() bool {
+		return apierrors.IsNotFound(k8sClient.Get(t.Context(), types.NamespacedName{
+			Name: "disc-server", Namespace: namespace.Name,
+		}, &ogxiov1beta1.OGXServer{}))
+	}, testTimeout, testInterval, "OGXServer should be deleted")
+
+	// --- assert: adopted PVC survives CR deletion with labels intact ---
+	require.NoError(t, k8sClient.Get(t.Context(), pvcKey, pvc),
+		"Adopted PVC must survive OGXServer deletion")
+	require.Equal(t, "disc-legacy", pvc.Labels[ogxiov1beta1.AdoptedFromLabel],
+		"Adopted-from label must be unchanged after CR deletion")
+	require.Equal(t, "disc-server", pvc.Labels["app.kubernetes.io/instance"],
+		"Instance label must be unchanged after CR deletion")
+
+	// --- act: recreate OGXServer with same name ---
+	instance = NewOGXServerBuilder().
+		WithName("disc-server").
+		WithNamespace(namespace.Name).
+		WithStorage(DefaultTestStorage()).
+		Build()
+
+	require.NoError(t, k8sClient.Create(t.Context(), instance))
+	t.Cleanup(func() {
+		if err := k8sClient.Delete(t.Context(), instance); err != nil && !apierrors.IsNotFound(err) {
+			t.Logf("Cleanup: %v", err)
+		}
+	})
+
+	ReconcileOGXServer(t, instance)
+
+	// --- assert: adopted PVC discovered, no default PVC created ---
+	require.NoError(t, k8sClient.Get(t.Context(), pvcKey, pvc),
+		"Adopted PVC must still exist after recreate")
+	require.True(t, apierrors.IsNotFound(k8sClient.Get(t.Context(), defaultKey, &corev1.PersistentVolumeClaim{})),
+		"Default PVC should NOT be created when adopted PVC is discovered by label")
+
+	require.NoError(t, k8sClient.Get(t.Context(), deployKey, deployment))
+	AssertDeploymentUsesPVCStorage(t, deployment, "disc-legacy-pvc")
 }
 
 func TestAdoptionRejectsUnexpectedControllerOwner(t *testing.T) {
@@ -666,6 +707,71 @@ func TestAdoptionRejectsUnexpectedControllerOwner(t *testing.T) {
 	})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to adopt")
+}
+
+func TestMultipleAdoptedPVCsReturnsTerminalError(t *testing.T) {
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+	namespace := createTestNamespace(t, "adopt-multi-pvc")
+
+	// --- arrange: create two PVCs with matching adoption labels ---
+	for _, pvcName := range []string{"first-pvc", "second-pvc"} {
+		storageSize := resource.MustParse("1Gi")
+		pvc := &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      pvcName,
+				Namespace: namespace.Name,
+				Labels: map[string]string{
+					ogxiov1beta1.AdoptedFromLabel: "some-legacy",
+					"app.kubernetes.io/instance":  "multi-test",
+				},
+			},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceStorage: storageSize,
+					},
+				},
+			},
+		}
+		require.NoError(t, k8sClient.Create(t.Context(), pvc))
+		t.Cleanup(func() {
+			if err := k8sClient.Delete(t.Context(), pvc); err != nil && !apierrors.IsNotFound(err) {
+				t.Logf("Cleanup PVC: %v", err)
+			}
+		})
+	}
+
+	instance := NewOGXServerBuilder().
+		WithName("multi-test").
+		WithNamespace(namespace.Name).
+		WithStorage(DefaultTestStorage()).
+		Build()
+
+	require.NoError(t, k8sClient.Create(t.Context(), instance))
+	t.Cleanup(func() {
+		if err := k8sClient.Delete(t.Context(), instance); err != nil && !apierrors.IsNotFound(err) {
+			t.Logf("Cleanup: %v", err)
+		}
+	})
+
+	// --- act ---
+	reconciler := createTestReconciler()
+	result, err := reconciler.Reconcile(t.Context(), ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      instance.Name,
+			Namespace: instance.Namespace,
+		},
+	})
+
+	// --- assert: no error returned (terminal), no requeue ---
+	require.NoError(t, err, "terminal error should not propagate as a reconcile error")
+	require.Zero(t, result.RequeueAfter, "should not requeue on terminal error")
+
+	require.NoError(t, k8sClient.Get(t.Context(), types.NamespacedName{
+		Name: instance.Name, Namespace: instance.Namespace,
+	}, instance))
+	assertConditionTrue(t, instance, "AdoptionConfigInvalid")
 }
 
 // --- Helpers ---

--- a/controllers/ogxserver_controller.go
+++ b/controllers/ogxserver_controller.go
@@ -157,13 +157,8 @@ func (r *OGXServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// Reconcile all resources, storing the error for later.
 	reconcileErr := r.reconcileResources(ctx, instance)
 
-	// Handle adoption requeue: not a real error, just needs a delayed retry.
-	var requeueErr *requeueError
-	if errors.As(reconcileErr, &requeueErr) {
-		if statusUpdateErr := r.updateStatus(ctx, instance, nil); statusUpdateErr != nil {
-			logger.Error(statusUpdateErr, "failed to update status during adoption requeue")
-		}
-		return ctrl.Result{RequeueAfter: requeueErr.after}, nil
+	if result, done := r.handleSentinelErrors(ctx, instance, reconcileErr); done {
+		return result, nil
 	}
 
 	// Update the status, passing in any reconciliation error.
@@ -526,6 +521,40 @@ type requeueError struct {
 
 func (e *requeueError) Error() string {
 	return fmt.Sprintf("requeue after %s", e.after)
+}
+
+// terminalError signals a problem that cannot be resolved by retrying.
+// The reconciler sets a status condition and stops without requeueing.
+type terminalError struct {
+	message string
+}
+
+func (e *terminalError) Error() string {
+	return e.message
+}
+
+func (r *OGXServerReconciler) handleSentinelErrors(
+	ctx context.Context, instance *ogxiov1beta1.OGXServer, reconcileErr error,
+) (ctrl.Result, bool) {
+	logger := log.FromContext(ctx)
+
+	var requeueErr *requeueError
+	if errors.As(reconcileErr, &requeueErr) {
+		if statusUpdateErr := r.updateStatus(ctx, instance, nil); statusUpdateErr != nil {
+			logger.Error(statusUpdateErr, "failed to update status during adoption requeue")
+		}
+		return ctrl.Result{RequeueAfter: requeueErr.after}, true
+	}
+
+	var termErr *terminalError
+	if errors.As(reconcileErr, &termErr) {
+		if statusUpdateErr := r.updateStatus(ctx, instance, nil); statusUpdateErr != nil {
+			logger.Error(statusUpdateErr, "failed to update status for terminal error")
+		}
+		return ctrl.Result{}, true
+	}
+
+	return ctrl.Result{}, false
 }
 
 func (r *OGXServerReconciler) reconcileConfigMaps(ctx context.Context, instance *ogxiov1beta1.OGXServer) error {

--- a/controllers/ogxserver_controller_test.go
+++ b/controllers/ogxserver_controller_test.go
@@ -149,6 +149,69 @@ func TestStorageConfiguration(t *testing.T) {
 	}
 }
 
+func TestDefaultPVCLifecycle(t *testing.T) {
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+
+	// --- arrange ---
+	namespace := createTestNamespace(t, "pvc-lifecycle")
+	pvcName := "pvc-test-pvc"
+	pvcKey := types.NamespacedName{Name: pvcName, Namespace: namespace.Name}
+	crKey := types.NamespacedName{Name: "pvc-test", Namespace: namespace.Name}
+
+	// --- act: create OGXServer with storage ---
+	instance := NewOGXServerBuilder().
+		WithName("pvc-test").
+		WithNamespace(namespace.Name).
+		WithStorage(DefaultTestStorage()).
+		Build()
+	require.NoError(t, k8sClient.Create(t.Context(), instance))
+
+	ReconcileOGXServer(t, instance)
+
+	// --- assert: PVC created without ownerRef, Deployment references it ---
+	pvc := AssertPVCExists(t, k8sClient, namespace.Name, pvcName)
+	require.Nil(t, metav1.GetControllerOf(pvc),
+		"Default PVC should not have a controller ownerRef")
+
+	deployment := &appsv1.Deployment{}
+	waitForResource(t, k8sClient, namespace.Name, "pvc-test", deployment)
+	AssertDeploymentUsesPVCStorage(t, deployment, pvcName)
+
+	// --- act: delete OGXServer ---
+	require.NoError(t, k8sClient.Delete(t.Context(), instance))
+	require.Eventually(t, func() bool {
+		return apierrors.IsNotFound(k8sClient.Get(t.Context(), crKey, &ogxiov1beta1.OGXServer{}))
+	}, testTimeout, testInterval, "OGXServer should be deleted")
+
+	// --- assert: PVC survives CR deletion ---
+	require.NoError(t, k8sClient.Get(t.Context(), pvcKey, pvc),
+		"PVC must survive OGXServer deletion")
+
+	// --- act: recreate OGXServer with same name ---
+	instance = NewOGXServerBuilder().
+		WithName("pvc-test").
+		WithNamespace(namespace.Name).
+		WithStorage(DefaultTestStorage()).
+		Build()
+	require.NoError(t, k8sClient.Create(t.Context(), instance))
+	t.Cleanup(func() {
+		if err := k8sClient.Delete(t.Context(), instance); err != nil && !apierrors.IsNotFound(err) {
+			t.Logf("Cleanup: %v", err)
+		}
+	})
+
+	ReconcileOGXServer(t, instance)
+
+	// --- assert: PVC reused, Deployment references it ---
+	require.NoError(t, k8sClient.Get(t.Context(), pvcKey, pvc),
+		"PVC must still exist after recreate")
+	require.Nil(t, metav1.GetControllerOf(pvc),
+		"Reused PVC should still not have a controller ownerRef")
+
+	require.NoError(t, k8sClient.Get(t.Context(), crKey, deployment))
+	AssertDeploymentUsesPVCStorage(t, deployment, pvcName)
+}
+
 func TestConfigMapWatchingFunctionality(t *testing.T) {
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 

--- a/release/operator.yaml
+++ b/release/operator.yaml
@@ -10,7 +10,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: system/serving-cert
+    cert-manager.io/inject-ca-from: ogx-k8s-operator-system/ogx-k8s-operator-serving-cert
     controller-gen.kubebuilder.io/version: v0.17.2
   labels:
     app.kubernetes.io/name: ogx-k8s-operator
@@ -6988,22 +6988,22 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: serving-cert
-  namespace: system
+  name: ogx-k8s-operator-serving-cert
+  namespace: ogx-k8s-operator-system
 spec:
   dnsNames:
   - ogx-k8s-operator-webhook-service.ogx-k8s-operator-system.svc
   - ogx-k8s-operator-webhook-service.ogx-k8s-operator-system.svc.cluster.local
   issuerRef:
     kind: Issuer
-    name: selfsigned-issuer
+    name: ogx-k8s-operator-selfsigned-issuer
   secretName: ogx-k8s-operator-webhook-cert
 ---
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name: selfsigned-issuer
-  namespace: system
+  name: ogx-k8s-operator-selfsigned-issuer
+  namespace: ogx-k8s-operator-system
 spec:
   selfSigned: {}
 ---
@@ -7011,7 +7011,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: system/serving-cert
+    cert-manager.io/inject-ca-from: ogx-k8s-operator-system/ogx-k8s-operator-serving-cert
   labels:
     app.kubernetes.io/name: ogx-k8s-operator
   name: ogx-k8s-operator-validating-webhook-configuration


### PR DESCRIPTION
- Replace AdoptedFromAnnotation with AdoptedFromLabel for all adopted resources, enabling server-side filtering via HasLabels in cleanup
- Add terminalError type so multiple-adopted-PVC conflicts set a condition and stop reconciling without requeue
- Replace Service selector merge with full replacement during adoption
- Expand test coverage: PVC lifecycle (create, survive CR deletion, re-adopt) and multiple-PVC terminal error
- Fix cert-manager kustomization to include namespace and namePrefix